### PR TITLE
Fix the syntax error in the uninstall script.

### DIFF
--- a/uninstall
+++ b/uninstall
@@ -2,7 +2,7 @@
 
 rm -rf $HOME/.emacs_anywhere
 
-if [[ $OSTYPE == "darwin"*]]
+if [[ $OSTYPE == "darwin"* ]]
 then
    rm -rf $HOME/Library/Services/Emacs\ Anywhere.workflow
 fi


### PR DESCRIPTION
Hi,

This is a minor fix in the uninstall script for the osx (darwin*) condition.

With regards,
Sourena