### PR TITLE
Improved Linux support

### DIFF
--- a/bin/linux
+++ b/bin/linux
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-window=$( xdotool getwindowfocus )
+window=$( xdotool getactivewindow || xdotool getwindowfocus )
 
 $HOME/.emacs_anywhere/bin/emacstask
 

--- a/bin/linux
+++ b/bin/linux
@@ -8,6 +8,4 @@ xdotool windowfocus --sync $window
 
 clipboard="$( cat $HOME/.emacs_anywhere/clipboard | tr \\n \\r | sed s/\\r*\$// )"
 
-echo $clipboard >> ~/log
-
 xdotool type --delay 1 "$clipboard"

--- a/bin/linux
+++ b/bin/linux
@@ -1,7 +1,13 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-window=$( xdotool getactivewindow )
+window=$( xdotool getwindowfocus )
 
 $HOME/.emacs_anywhere/bin/emacstask
 
-xdotool windowactivate --sync $window key --clearmodifiers ctrl+v
+xdotool windowfocus --sync $window
+
+clipboard=$( cat $HOME/.emacs_anywhere/clipboard )
+
+echo $clipboard >> ~/log
+
+xdotool type "$clipboard"

--- a/bin/linux
+++ b/bin/linux
@@ -6,8 +6,8 @@ $HOME/.emacs_anywhere/bin/emacstask
 
 xdotool windowfocus --sync $window
 
-clipboard=$( cat $HOME/.emacs_anywhere/clipboard )
+clipboard="$( cat $HOME/.emacs_anywhere/clipboard | tr \\n \\r | sed s/\\r*\$// )"
 
 echo $clipboard >> ~/log
 
-xdotool type "$clipboard"
+xdotool type --delay 1 "$clipboard"

--- a/bin/linux
+++ b/bin/linux
@@ -8,4 +8,4 @@ xdotool windowfocus --sync $window
 
 clipboard="$( cat $HOME/.emacs_anywhere/clipboard | tr \\n \\r | sed s/\\r*\$// )"
 
-xdotool type --delay 1 "$clipboard"
+xdotool type --clearmodifiers --delay 1 "$clipboard"

--- a/bin/linux
+++ b/bin/linux
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-window=$( xdotool getactivewindow || xdotool getwindowfocus )
+window="$( xdotool getactivewindow || xdotool getwindowfocus )"
 
 $HOME/.emacs_anywhere/bin/emacstask
 

--- a/emacs_anywhere.el
+++ b/emacs_anywhere.el
@@ -6,14 +6,16 @@
    (point-max))
   (kill-buffer "*Emacs Anywhere*"))
 
-(defun ea-on-delete2 (frame)
-  (f-write (buffer-string) 'utf-8 "/home/sibi/.emacs_anywhere/clipboard"))
+(defun ea-on-delete3 (frame)
+  (write-region (point-min) (point-max) "~/.emacs_anywhere/clipboard")
+  (kill-buffer "*Emacs Anywhere*")
+  )
 
 (defun ea-hook ()
-  (add-hook 'delete-frame-functions 'ea-on-delete2))
+  (add-hook 'delete-frame-functions 'ea-on-delete3))
 
 (defun ea-unhook ()
-  (remove-hook 'delete-frame-functions 'ea-on-delete2))
+  (remove-hook 'delete-frame-functions 'ea-on-delete3))
 
 (defun emacs-anywhere ()
   (interactive)
@@ -24,3 +26,4 @@
 (ea-hook)
 (switch-to-buffer "*Emacs Anywhere*")
 (select-frame-set-input-focus (selected-frame))
+

--- a/emacs_anywhere.el
+++ b/emacs_anywhere.el
@@ -1,14 +1,19 @@
+(require 'f)
+
 (defun ea-on-delete (frame)
   (clipboard-kill-ring-save
    (point-min)
    (point-max))
   (kill-buffer "*Emacs Anywhere*"))
 
+(defun ea-on-delete2 (frame)
+  (f-write (buffer-string) 'utf-8 "/home/sibi/.emacs_anywhere/clipboard"))
+
 (defun ea-hook ()
-  (add-hook 'delete-frame-functions 'ea-on-delete))
+  (add-hook 'delete-frame-functions 'ea-on-delete2))
 
 (defun ea-unhook ()
-  (remove-hook 'delete-frame-functions 'ea-on-delete))
+  (remove-hook 'delete-frame-functions 'ea-on-delete2))
 
 (defun emacs-anywhere ()
   (interactive)

--- a/emacs_anywhere.el
+++ b/emacs_anywhere.el
@@ -1,21 +1,24 @@
-(require 'f)
-
-(defun ea-on-delete (frame)
+(defun ea-on-mac ()
   (clipboard-kill-ring-save
    (point-min)
    (point-max))
   (kill-buffer "*Emacs Anywhere*"))
 
-(defun ea-on-delete3 (frame)
+(defun ea-on-linux ()
   (write-region (point-min) (point-max) "~/.emacs_anywhere/clipboard")
   (kill-buffer "*Emacs Anywhere*")
   )
 
+(defun ea-on-delete (frame)
+  (if (eq system-type 'darwin)
+      (ea-on-mac)
+    (ea-on-linux)))
+
 (defun ea-hook ()
-  (add-hook 'delete-frame-functions 'ea-on-delete3))
+  (add-hook 'delete-frame-functions 'ea-on-delete))
 
 (defun ea-unhook ()
-  (remove-hook 'delete-frame-functions 'ea-on-delete3))
+  (remove-hook 'delete-frame-functions 'ea-on-delete))
 
 (defun emacs-anywhere ()
   (interactive)
@@ -26,4 +29,3 @@
 (ea-hook)
 (switch-to-buffer "*Emacs Anywhere*")
 (select-frame-set-input-focus (selected-frame))
-

--- a/uninstall
+++ b/uninstall
@@ -2,7 +2,7 @@
 
 rm -rf $HOME/.emacs_anywhere
 
-if [[ $OSTYPE == "darwin"*]]
+if [[ $OSTYPE == "darwin"* ]]
 then
    rm -rf $HOME/Library/Services/Emacs\ Anywhere.workflow
 fi


### PR DESCRIPTION
This PR only changes the logic for Linux machines. ( I will probably get back to Mac once I get to installing there in a couple of days).

Noteworthy changes:
* This patch enables emacs-anywhere to literally work everywhere. Previously there was a reliance on the Key binding `Ctrl + V` to paste it. I have removed that and instead just used the typing feature of xdotool.
* No more reliance on clipboard for this feature to actually work. It's quite hard to make clipboards behave properly in Linux (this software didn't work for me using clipboard). Also I wouldn't want this program to modify my clipboard. See @beshrkayali comment here: https://github.com/zachcurry/emacs-anywhere/issues/18#issuecomment-370259456

For folks who are testing this PR, if you are using this plugin alrady - please close your emacs daemon and clients before trying it. I lost quite some hours because of that.

And yeah, this comment is being typed via Emacs!