### PR TITLE
install: Check that we're in the root of the repo

### DIFF
--- a/install
+++ b/install
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+[[ -r emacs_anywhere.el ]] || { echo "Please run from the root of the repo"; exit 1; }
+
 ROOT_ABS_PATH=$( pwd -P $0 )
 EA=$HOME/.emacs_anywhere
 


### PR DESCRIPTION
This script relies on being executed from the root of the repo, so error out if it's not.

---

The alternative to this (which will be in the next PR I open) is to not require the install script to be run from the root of the repo.