### PR TITLE
install: Don't require install script to be run from root of repo

### DIFF
--- a/install
+++ b/install
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-ROOT_ABS_PATH=$( pwd -P $0 )
+ROOT_ABS_PATH=$( dirname $0 )
 EA=$HOME/.emacs_anywhere
 
 shared_install () {


### PR DESCRIPTION
This is an alternative to #32.

It introduces a possible new dependency: `dirname`.  It seems like a utility that's commonly enough installed that the additional dependency could be tolerable.