### PR TITLE
EA_TITLE environment was added.

### DIFF
--- a/bin/emacstask
+++ b/bin/emacstask
@@ -6,7 +6,11 @@ if [ -z "$EA_EDITOR" ]; then
     EA_EDITOR='emacsclient -a "" -c'
 fi
 
-$EA_EDITOR -e "(progn
+if [ -z "$EA_TITLE" ]; then
+    EA_TITLE='emacsanywhere'
+fi
+
+$EA_EDITOR -F "((name . \"$EA_TITLE\"))" -e "(progn
                  (defconst ea-app-name $EA_APP_NAME)
                  (defconst ea-window-title $EA_WINDOW_TITLE)
                  (defconst ea-x $EA_X)


### PR DESCRIPTION
* Many tiling windows managers find and handle windows by their title.
* For finding emacs anywhere's window, we need to set a different title with other emacs window.
* So, I added `$EA_TITLE` environment in order to set the window's title.
  * By default, it uses `emacsanywhere` as `$EA_TITLE`.